### PR TITLE
#45 Solved login and contact listing problems. Added IDLE status.

### DIFF
--- a/src/main/java/fr/delthas/skype/NotifConnector.java
+++ b/src/main/java/fr/delthas/skype/NotifConnector.java
@@ -824,11 +824,7 @@ class NotifConnector {
   }
   
   private String getSelfLiveUsername() {
-    if (microsoft) {
-      return "live:" + username.substring(0, username.indexOf('@'));
-    } else {
-      return username;
-    }
+    return skype.getUser(username).getLiveUsername();
   }
   
   private static class Packet {

--- a/src/main/java/fr/delthas/skype/Presence.java
+++ b/src/main/java/fr/delthas/skype/Presence.java
@@ -13,6 +13,10 @@ public enum Presence {
    */
   AWAY("AWY"),
   /**
+   * Idle / Absent
+   */
+  IDLE("IDL"),
+  /**
    * Busy / Do Not Disturb (red sign on Skype)
    */
   BUSY("BSY"),

--- a/src/main/java/fr/delthas/skype/Skype.java
+++ b/src/main/java/fr/delthas/skype/Skype.java
@@ -48,6 +48,7 @@ public final class Skype {
   private boolean connecting = false;
   private volatile long expires;
   private IOException exceptionDuringConnection;
+  private User me;
   
   // --- Public API (except listeners add/remove methods) --- //
   

--- a/src/main/java/fr/delthas/skype/User.java
+++ b/src/main/java/fr/delthas/skype/User.java
@@ -21,6 +21,7 @@ public class User {
   private String city;
   private String displayName;
   private String avatarUrl;
+  private String liveUsername;
   private Presence presence = Presence.OFFLINE;
   
   User(Skype skype, String username) {
@@ -245,6 +246,14 @@ public class User {
         skype.userPresenceChanged(this, oldPresence, presence);
       }
     }
+  }
+  
+  public String getLiveUsername() {
+    return liveUsername;
+  }
+
+  public void setLiveUsername(String liveUsername) {
+    this.liveUsername = liveUsername;
   }
   
   @Override

--- a/src/main/java/fr/delthas/skype/WebConnector.java
+++ b/src/main/java/fr/delthas/skype/WebConnector.java
@@ -86,10 +86,12 @@ class WebConnector {
     updated = true;
     String selfResponse = sendRequest(Method.GET, "/users/self/profile").body();
     JSONObject selfJSON = new JSONObject(selfResponse);
-    updateUser(selfJSON, false);
+    
+    User loggedUser = updateUser(selfJSON, false, username);
     
     String profilesResponse =
-            sendRequest(Method.GET, "https://contacts.skype.com/contacts/v2/users/" + getSelfLiveUsername() + "/contacts", true).body();
+            sendRequest(Method.GET, "https://contacts.skype.com/contacts/v2/users/" + loggedUser.getLiveUsername() + "/contacts", true).body();
+    
     try {
       JSONObject json = new JSONObject(profilesResponse);
       if (json.optString("message", null) != null) {
@@ -108,6 +110,10 @@ class WebConnector {
   }
   
   private User updateUser(JSONObject userJSON, boolean newContactType) throws ParseException {
+    return updateUser(userJSON, newContactType, null);
+  }
+  
+  private User updateUser(JSONObject userJSON, boolean newContactType, String username) throws ParseException {
     String userUsername;
     String userFirstName = null;
     String userLastName = null;
@@ -146,9 +152,15 @@ class WebConnector {
         userUsername = mri.substring(senderBegin + 1);
         userDisplayName = userJSON.optString("display_name", null);
         JSONObject profileJSON = userJSON.getJSONObject("profile");
-        JSONObject nameJSON = profileJSON.getJSONObject("name");
-        userFirstName = nameJSON.optString("first", null);
-        userLastName = nameJSON.optString("surname", null);
+        
+        userFirstName = userUsername;
+        userLastName = "";
+        if (profileJSON.has("name")) {
+            JSONObject nameJSON = profileJSON.getJSONObject("name");
+            userFirstName = nameJSON.optString("first", null);
+            userLastName = nameJSON.optString("surname", null);
+        }
+        
         userMood = profileJSON.optString("mood", null);
         if (profileJSON.has("locations")) {
           JSONObject locationJSON = profileJSON.optJSONArray("locations").optJSONObject(0);
@@ -162,7 +174,7 @@ class WebConnector {
     } catch (JSONException e) {
       throw new ParseException(e);
     }
-    User user = skype.getUser(userUsername);
+    User user = skype.getUser(username != null ? username : userUsername);
     user.setCity(getPlaintext(userCity));
     user.setCountry(getPlaintext(userCountry));
     user.setDisplayName(getPlaintext(userDisplayName));
@@ -170,6 +182,7 @@ class WebConnector {
     user.setLastName(getPlaintext(userLastName));
     user.setMood(getPlaintext(userMood));
     user.setAvatarUrl(userAvatarUrl);
+    user.setLiveUsername(userUsername);
     return user;
   }
   
@@ -230,13 +243,5 @@ class WebConnector {
   
   private Response sendRequest(Method method, String apiPath, String... keyval) throws IOException {
     return sendRequest(method, apiPath, false, keyval);
-  }
-  
-  private String getSelfLiveUsername() {
-    if (username.contains("@")) {
-      return "live:" + username.substring(0, username.indexOf('@'));
-    } else {
-      return username;
-    }
   }
 }


### PR DESCRIPTION
I've got it working with an older Skype account, and two newer ones from Microsoft.

- getSelfLiveUsername() functions were returning wrong live:usernames for some of my accounts. Apparently, when emails with same user for different domains are registered, Microsoft adds a number to the end of the live username, e.g: live:skype1_30. Changed to update the live username received on updateContacts(). This has solved all login problems I've encountered.
- Added IDLE status to Presence. When left for some time, my skype sent this status to the server and exceptions were thrown, sometimes when logging in.
- For one of my contacts the server did not return the "name" key on WebConnector:updateUser. Added a default value.